### PR TITLE
updated handleChange and handleOpen properties for react 0.14.0 version

### DIFF
--- a/lib/select-box.js
+++ b/lib/select-box.js
@@ -100,7 +100,7 @@ module.exports = React.createClass({displayName: 'exports',
       } else {
         this.updatePendingValue(val, cb) || this.props.onChange(val)
         this.handleClose()
-        this.refs.button.getDOMNode().focus()
+        this.refs.button.focus()
       }
     }.bind(this)
   },
@@ -140,7 +140,7 @@ module.exports = React.createClass({displayName: 'exports',
   handleOpen: function (event) {
     interceptEvent(event)
     this.setState({open: true}, function () {
-      this.refs.menu.getDOMNode().focus()
+      this.refs.menu.focus()
     })
   },
 


### PR DESCRIPTION
In react 0.14.0 version I am getting this warning 
"Warning: ReactDOMComponent: Do not access .getDOMNode() of a DOM node; instead, use the node directly. This DOM node was rendered by 'exports' " .  I have fixed this issue please review it and merge the changes. 
Thanks !!
